### PR TITLE
Simplify top right header navigation to just search, about page and Iocale switcher

### DIFF
--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -55,17 +55,6 @@ button.navbar-toggler {
   color: $dark-grey; /* Add a dark-grey background on hover */
 }
 
-@include media-breakpoint-up(lg) {
-  #nav-only-mobile  {
-    display: none;
-  }
-}
-
-@include media-breakpoint-down(lg) {
-  #nav-only-screen  {
-    display: none;
-  }
-}
 @include media-breakpoint-down(md) {
   .display-3 {
     font-size: 3.5rem;

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -26,6 +26,21 @@
     border-bottom: 0.5px solid $white;
   }
 
+  .form-inline.search {
+    position: relative;
+    margin-right: 12px;
+
+    input {
+      padding-right: 40px;
+      text-overflow: ellipsis;
+    }
+
+    .btn {
+      position: absolute;
+      right: 0;
+    }
+  }
+
   .language-switcher {
     margin-left: 6px;
     a {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,12 +37,12 @@ module ApplicationHelper
     end
     links = [:de, :en].map do |lang|
       if lang == I18n.locale
-        link_to(lang.to_s.upcase, target_url, class: 'nav-link active')
+        link_to(lang.to_s, target_url, class: 'nav-link active')
       else
-        link_to(lang.to_s.upcase, target_url.sub(/\/(de|en)\//,"/#{lang.to_s}/"))
+        link_to(lang.to_s, target_url.sub(/\/(de|en)\//,"/#{lang.to_s}/"))
       end
     end
-    links.join(' | ')
+    links.join('·')
   end
 
   def markdown(text, options={})

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light fixed-top" id="header">
-  <div class="container px-3">
+  <div class="container">
     <a class="navbar-brand" href="<%= root_path %>/">
       <h1 class="display-3">
         <%= t 'layout.header.title' %>
@@ -13,8 +13,7 @@
 
     <!-- Collect the nav links, forms, and other content for toggling -->
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
-      <section id="nav-only-mobile">
-        <ul class="navbar-nav mr-auto mt-2 mt-lg-0">
+        <ul class="navbar-nav ml-md-auto">
           <li class="nav-item">
             <a href="#sidebar-search" class="nav-link">
               <span class="fa fa-search"></span>&nbsp;
@@ -22,19 +21,11 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="#statistics" class="nav-link">
-              <span class="fa fa-adjust"></span>&nbsp;
-              <%= t 'layout.sidebar.statistics' %>
+            <a href="/p/about" class="nav-link">
+              <span class="fa fa-info"></span>&nbsp;
+              <%= t 'layout.header.about' %>
             </a>
           </li>
-          <li class="nav-item">
-            <a href="#tags">
-              <span class="fa fa-tag"></span>&nbsp;
-              Tags
-            </a>
-          </li>
-
-          <li role="presentation" class="divider"></li>
 
           <% Page.sidebar_snippets.order(:rank).includes(:translations).all.each do |snippet| %>
             <li class="nav-item">
@@ -44,8 +35,6 @@
               </a>
             </li>
           <% end %>
-
-          <li role="presentation" class="divider"></li>
 
           <% Page.menu_pages.order(:rank).includes(:translations).all.each do |page| %>
             <li class="nav-item">
@@ -67,25 +56,9 @@
             </li>
           <% end %>
         </ul>
-      </section><!-- /.nav-only-mobile -->
     </div><!-- /.navbar-collapse -->
 
     <a onclick="topFunction()" id="btn-top" title="Go to top"><i class="fa fa-arrow-circle-up"></i></a>
-    
-    <div id="nav-only-screen">
-      <ul class="navbar-nav mr-auto">
-        <li class="language-switcher">
-          <%= language_switcher.html_safe %>
-        </li>
-        <% if current_user %>
-          <li>
-            <%= link_to admin_root_path do %>
-              <span class="fa fa-cog"></span>
-            <% end %>
-          </li>
-        <% end %>
-      </ul>
-    </div>
   </div>
 
 </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,10 +15,16 @@
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav ml-md-auto">
           <li class="nav-item">
-            <a href="#sidebar-search" class="nav-link">
-              <span class="fa fa-search"></span>&nbsp;
-              <%= t 'layout.sidebar.search' %>
-            </a>
+              <%= form_tag(events_path, method: 'get', class: 'form-inline search', role: 'form') do %>
+                <div class="form-group">
+                  <%= text_field_tag(:q, params[:q],  {class: 'form-control',
+                                                       placeholder: t('layout.sidebar.searchterm')
+                                                       }) %>
+                  <%= button_tag( class: "btn") do %>
+                  <span class="fa fa-search"></span>
+                </div>
+                <% end %>
+              <% end %>
           </li>
           <li class="nav-item">
             <a href="/p/about" class="nav-link">

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -5,20 +5,6 @@
   <% end %>
 </aside>
 
-<aside class="widget" id="sidebar-search">
-  <h6><%= t 'layout.sidebar.search' %></h6>
-  <%= form_tag(events_path, method: 'get', class: 'form-inline search', role: 'form') do %>
-    <div class="form-group">
-      <%= text_field_tag(:q, params[:q],  {class: 'form-control',
-                                           placeholder: t('layout.sidebar.searchterm')
-                                           }) %>
-      <%= button_tag( class: "btn btn-primary") do %>
-      <span class="fa fa-search"></span>
-    </div>
-    <% end %>
-  <% end %>
-</aside>
-
 <aside class="widget" id="statistics">
   <h6><%= t 'layout.sidebar.statistics' %></h6>
   <p>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -93,6 +93,7 @@ de:
     header:
       title: 50 Prozent
       claim: sind die Hälfte.
+      about: Über
     sidebar:
       add_new_event_html: 'Neue Veranstaltung <span class="d-none d-md-inline-block">eintragen</span>'
       more: Mehr

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -92,6 +92,7 @@ en:
     header:
       title: 50 percent
       claim: "that's half of it"
+      about: About
     sidebar:
       add_new_event_html: 'Add new event'
       more: More


### PR DESCRIPTION
Moved "Search" and "About" into the header and simplified it on mobile.

Next steps would be to:
- Remove the right sidebar to just have one list
- Create a header section
- Put the "Add event" thing on top of the list or in header
- Complete the "About" page
- Have the search field directly in the header

→ Will do those in a separate pull request. :)

Please check @alicetragedy @tyranja 🛃

## On desktop
Before
![50percent header before](https://user-images.githubusercontent.com/925062/62873020-ec249600-bd1e-11e9-98e0-12b8258ccf54.png)
After
![50percent header after](https://user-images.githubusercontent.com/925062/62873023-ec249600-bd1e-11e9-966b-8b21d4541415.png)


## On mobile
Before
![Header mobile before](https://user-images.githubusercontent.com/925062/62873019-ec249600-bd1e-11e9-9a2c-a6829d2cf5dc.png)
After
![header mobile after](https://user-images.githubusercontent.com/925062/62873017-eb8bff80-bd1e-11e9-92c7-5408101e8f1b.png)
