### PR TITLE
Switch sorting default to date and remove sort option

### DIFF
--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -24,7 +24,7 @@ class Admin::EventsController < Admin::BaseController
     when 'date'
       @events = @events.order(date: :desc)
     else
-      @events = @events.order(created_at: :desc)
+      @events = @events.order(date: :desc)
     end
 
     @events = @events.includes(:comments).page(params[:page]).per(40)

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -14,7 +14,7 @@ class EventsController < ApplicationController
     when 'date'
       @events = @events.where.not(date: [nil,""]).order(date: :desc)
     else
-      @events = @events.order(created_at: :desc)
+      @events = @events.order(date: :desc)
     end
 
     @events = @events.includes(:comments).page(params[:page])

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,14 +1,5 @@
 <%= render partial: 'tag_or_search_summery' %>
 
-<div class="row m-0 mb-3 sorting">
-  <div class="col">
-    <%= link_to_unless(params[:order_by] == "date", '<i class="fa fa-sort"></i>'.html_safe + t('index.date').html_safe, events_path(order_by: "date"), class:'pr-3' ) %>
-  </div>
-  <div class="col">
-  <%= link_to_unless(params[:order_by] == "created_at" || params[:order_by] == nil, '<i class="fa fa-sort"></i>'.html_safe + t('index.created_at').html_safe, events_path(order_by: "created_at"), class:'pl-3' ) %>
-  </div>
-</div>
-
 <%= render @events %>
 
 <% if @events.any? %>


### PR DESCRIPTION
Currently events are sorted by creation date. This is nice to show activity on the platform, but a kind of unusual sorting as events seem very mixed?

To improve the sorting more, we could sort more like Meetup.com for example does:
- First a section "**Upcoming events**" which would show the next one on top and going down into the future.
- Then below that a section for "**Past events**" listing by most recent up top.

What do you think @alicetragedy @tyranja?