### PR TITLE
Remove sidebar, simplify view

### DIFF
--- a/app/assets/stylesheets/_article.scss
+++ b/app/assets/stylesheets/_article.scss
@@ -5,10 +5,6 @@ article {
   border-radius: $border-radius-large;
   background-color: $body-bg;
 
-  h1 {
-    font-family: 'Montserrat Bold';
-  }
-
   .where-when {
     margin-top: 6px;
     padding-top: 8px;

--- a/app/assets/stylesheets/_typography.scss
+++ b/app/assets/stylesheets/_typography.scss
@@ -1,0 +1,11 @@
+html, body {
+  font-family: 'OpenSans';
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Montserrat';
+}
+
+h1 {
+  font-weight: bold;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,6 +20,7 @@
 
 // our partials
 @import "variables";
+@import "typography";
 @import "font-awesome";
 @import "bootstrap";
 @import "custom";

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,13 +1,13 @@
 /*fonts*/
 @font-face {
-  font-family: 'Montserrat Medium';
+  font-family: 'Montserrat';
   src:font-url('Montserrat-Medium.ttf') format('truetype');
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
-  font-family: 'Montserrat Bold';
+  font-family: 'Montserrat';
   src:font-url('Montserrat-Bold.ttf') format('truetype');
   font-weight: 700;
   font-style: normal;

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,21 +1,18 @@
 <article>
 
-  <h1><%= link_to event.title + ': ' , event %>
-
-    <% if event.has_all_the_numbers? %>
-      <%= link_to (t 'show.event.speaking', percent_male: event.percent_male), event,
+  <div class="main row">
+    <div class="col-md-4">
+      <% if event.has_all_the_numbers? %>
+        <%= render 'events/donut', event: event %>
+        <%= link_to (t 'show.event.speaking', percent_male: event.percent_male), event,
         class: "event__link--#{classname_for_event_title(event)}" %>
       <%# class will be event__link--more-male or more-female %>
-    <% end %>
-
-  </h1>
-  <% if event.description.present? %>
-    <div class="description"><%= simple_format(event.description) %></div>
-  <% end %>
-
-  <div class="main row">
+        <dt><%= t 'show.event.speaker_count' %>:</dt>
+          <dd><%= t 'show.event.speaker_count_statement', total: event.total.to_s %> <%= t 'show.event.woman', count: event.woman, women: event.woman.to_s %></dd>
+      <% end %>
+    </div>
     <div class="col-md-<%= event.has_all_the_numbers? ? '8' : '12' %>">
-
+      <h2><%= link_to event.title, event %></h2>
       <% unless event.date.blank? and event.city.blank? %>
         <div class="where-when">
           <span class="fa fa-calendar"></span>
@@ -25,6 +22,27 @@
           <%= event.city %>
         </div>
       <% end %>
+
+      <% if event.description.present? %>
+        <div class="description"><%= simple_format(event.description) %></div>
+      <% end %>
+
+      <% if event.tags.any? %>
+        <br>
+        <strong><%= t 'show.event.topic_tags' %>:</strong><br>
+        <% event.tags.each do |tag| %>
+          <%= link_to tag_path(tag: tag.name) do %>
+            <span class="badge"><%= tag.name %></span>
+          <% end %>
+        <% end %>
+      <% end %>
+
+    </div>
+  </div>
+  
+
+  <div class="main row">
+    <div class="col-md-<%= event.has_all_the_numbers? ? '8' : '12' %>"> 
 
       <% if is_single_view %>
         <dl class="dl-horizontal">
@@ -69,6 +87,12 @@
             <%= linked_contact_info(event.contact_email).html_safe %>
           </dd>
           <% end %>
+          <% if event.organizers.present? %>
+            <div class="organizers">
+              <strong><%= t 'show.event.organizers' %>:</strong>
+              <%= markdown(event.organizers, filter_html: true, link_attributes: {target: '_blank'}) %>
+            </div>
+          <% end %>
 
           <% if event.has_all_the_numbers? %>
           <br>
@@ -81,21 +105,6 @@
           <% end %>
         </dl>
 
-      <% else %>
-          
-          <% if event.has_all_the_numbers? %>
-          <br>
-            <dt><%= t 'show.event.speaker_count' %>:</dt>
-            <dd><%= t 'show.event.speaker_count_statement', total: event.total.to_s %> <%= t 'show.event.woman', count: event.woman, women: event.woman.to_s %></dd>
-          <% end %>
-
-        <% if event.organizers.present? %>
-          <div class="organizers">
-            <strong><%= t 'show.event.organizers' %>:</strong>
-            <%= markdown(event.organizers, filter_html: true, link_attributes: {target: '_blank'}) %>
-          </div>
-        <% end %>
-
       <% end %>
 
       <% if event.body %>
@@ -104,21 +113,6 @@
         </div>
       <% end %>
 
-      <% if event.tags.any? %>
-        <br>
-        <strong><%= t 'show.event.topic_tags' %>:</strong><br>
-        <% event.tags.each do |tag| %>
-          <%= link_to tag_path(tag: tag.name) do %>
-            <span class="badge"><%= tag.name %></span>
-          <% end %>
-        <% end %>
-        <br><br>
-      <% end %>
-    </div>
-    <div class="col-md-4">
-      <% if event.has_all_the_numbers? %>
-          <%= render 'events/donut', event: event %>
-      <% end %>
     </div>
 
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,5 +1,14 @@
 <%= render partial: 'tag_or_search_summery' %>
 
+<aside class='row'>
+  <div class='col-md-6 offset-md-3 mb-3'>
+    <%= link_to new_event_path, class: 'btn btn-primary btn-block' do %>
+      <span class="fa fa-plus-circle"></span>
+      <%= t 'layout.sidebar.add_new_event_html' %>
+    <% end %>
+  </div>
+</aside>
+
 <%= render @events %>
 
 <% if @events.any? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,19 +20,19 @@
     <% end %>
     <%= flash_messages %>
 
+    <aside class='row'>
+      <div class='col-md-6 offset-md-3 mb-3'>
+        <%= link_to new_event_path, class: 'btn btn-primary btn-block' do %>
+          <span class="fa fa-plus-circle"></span>
+          <%= t 'layout.sidebar.add_new_event_html' %>
+        <% end %>
+      </div>
+    </aside>
+
     <div class='row'>
-      <div class='col-md-12 col-lg-8'>
+      <div class='col-md-12'>
         <%= yield %>
       </div>
-      <% if layout_needs_sidebar?  %>
-        <div class='col-md-12 col-lg-4'>
-          <section id='sidebar'>
-            <%= render 'shared/sidebar' %>
-          </section>
-        </div>
-      <% else %>
-        <div class='col-md-12 col-lg-4'>&nbsp;</div>
-      <% end %>
     </div>
   </div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,14 +20,31 @@
     <% end %>
     <%= flash_messages %>
 
-    <aside class='row'>
-      <div class='col-md-6 offset-md-3 mb-3'>
-        <%= link_to new_event_path, class: 'btn btn-primary btn-block' do %>
-          <span class="fa fa-plus-circle"></span>
-          <%= t 'layout.sidebar.add_new_event_html' %>
-        <% end %>
+<!-- Possible landing page section
+    <section class="row" id="statistics">
+      <div class="col-md-12">
+        <h1 class="jumbotron-heading">Album example</h1>
+        <p class="lead text-muted">
+          <%= t 'layout.sidebar.statistics_statement_html',
+            {event_count: Event.published.counted.count,
+             total: total = Event.published.counted.pluck(:total).compact.sum,
+             women: woman = Event.published.counted.pluck(:woman).compact.sum,
+             percent: number_with_precision((woman.to_f / total.to_f) * 100, precision: 2)
+             }%>
+          <% total = Event.published.counted.pluck(:total).compact.sum %>
+          <% woman = Event.published.counted.pluck(:woman).compact.sum %>
+          <% percent_woman= number_with_precision((woman.to_f / total.to_f) * 100, precision: 2) %>
+          <%= render 'events/all_events_donut', percent: percent_woman.to_i %>
+        </p>
+        <p>
+          <%= link_to new_event_path, class: 'btn btn-primary   ' do %>
+            <span class="fa fa-plus-circle"></span>
+            <%= t 'layout.sidebar.add_new_event_html' %>
+          <% end %>
+        </p>
       </div>
-    </aside>
+    </section>
+-->
 
     <div class='row'>
       <div class='col-md-12'>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -41,15 +41,6 @@
     <% end %>
   </ul>
 </aside>
-<hr>
-<aside class="widget" id="tags">
-  <h6>Tags</h6>
-  <div id='tag_cloud'>
-    <% tag_cloud Event.tag_counts, %w[s m l] do |tag, css_class| %>
-      <%= link_to tag.name, tag_path(tag.name), class: css_class %>
-    <% end %>
-  </div>
-</aside>
 
 <aside class="widget text-right">
   <%= link_to admin_root_path, title: "Admin" do %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,19 +1,3 @@
-<aside class="widget" id="statistics">
-  <h6><%= t 'layout.sidebar.statistics' %></h6>
-  <p>
-    <%= t 'layout.sidebar.statistics_statement_html',
-          {event_count: Event.published.counted.count,
-           total: total = Event.published.counted.pluck(:total).compact.sum,
-           women: woman = Event.published.counted.pluck(:woman).compact.sum,
-           percent: number_with_precision((woman.to_f / total.to_f) * 100, precision: 2)
-           }%>
-    <% total = Event.published.counted.pluck(:total).compact.sum %>
-    <% woman = Event.published.counted.pluck(:woman).compact.sum %>
-    <% percent_woman= number_with_precision((woman.to_f / total.to_f) * 100, precision: 2) %>
-    <%= render 'events/all_events_donut', percent: percent_woman.to_i %>
-  </p>
-</aside>
-<hr>
 <% Page.sidebar_snippets.order(:rank).includes(:translations).all.each do |snippet| %>
   <aside class="widget" id="<%= dom_id(snippet) %>">
     <h6><%= snippet.title %></h6>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,10 +1,3 @@
-<aside class="widget">
-  <%= link_to new_event_path, class: 'btn btn-primary btn-block' do %>
-    <span class="fa fa-plus-circle"></span>
-    <%= t 'layout.sidebar.add_new_event_html' %>
-  <% end %>
-</aside>
-
 <aside class="widget" id="statistics">
   <h6><%= t 'layout.sidebar.statistics' %></h6>
   <p>


### PR DESCRIPTION
- Remove tag list from sidebar
- Remove sidebar, move add event button to content
- Move statistics from sidebar into possible front page head section, commented out

Separate things to do
- The "Add new event" button now shows on _every_ page now, including the "Add new event" page :D What to do here? Is there a specific "Frontpage" template?
- Similarly we need to think about how to handle a possible frontpage graphic, possibly using the main statistic. Not sure where to put that.
- The content of the "About" page and the sidebar is slightly different for some reason? Which is the latest version? @tyranja?


Before & after:

![Current site](https://user-images.githubusercontent.com/925062/64262384-4c79b280-cf2e-11e9-8173-2ceceb173435.png)


![This change](https://user-images.githubusercontent.com/925062/64262381-4c79b280-cf2e-11e9-872c-785209cc6d1c.png)