### PR TITLE
make changes to color palette for header and charts

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -23,11 +23,11 @@ body {
 }
 
 .event__link--more-male {
-    color: $blue;
+    color: $accent-light;
 }
 
 .event__link--more-female {
-    color: $red;
+    color: $accent;
 }
 
 .sorting {

--- a/app/assets/stylesheets/header.scss
+++ b/app/assets/stylesheets/header.scss
@@ -1,5 +1,5 @@
 #header {
-  background: $red;
+  background: $accent;
   color: white;
   padding: 0px;
 

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -51,6 +51,9 @@ $admin-steel-blue:   #4682B4;
 
 $yellow:             #FFBB00;
 
+$accent: #00978b;
+$accent-light: #A1D9D4;
+
 // Bootsrap Settings for the `<body>` element.
 $body-bg:            white !default;
 $body-color:         $dark-grey;

--- a/app/views/events/_all_events_donut.html.erb
+++ b/app/views/events/_all_events_donut.html.erb
@@ -10,10 +10,11 @@
        value: <%= percent %>},
     ],
     backgroundColor: 'whitesmoke',
+    formatter: function(y) { return y + "%"},
     labelColor: '#4E4E4E',
     colors: [
-      '#375E97',
-      '#E43A15'
+      '#A1D9D4',
+      '#00978b'
     ]
   });
 

--- a/app/views/events/_donut.html.erb
+++ b/app/views/events/_donut.html.erb
@@ -7,13 +7,14 @@
       {label: "<%= I18n.t 'show.event.donut.male' %>",
        value: <%= event.percent_male  %>},
       {label: "<%= I18n.t 'show.event.donut.female' %>",
-       value: <%= event.percent_female %>},
+       value: <%= event.percent_female %> },
     ],
+    formatter: function(y) { return y + "%"},
     backgroundColor: 'whitesmoke',
     labelColor: '#4E4E4E',
     colors: [
-      '#375E97',
-      '#c5141c'
+      '#A1D9D4',
+      '#00978b'
     ]
   });
 


### PR DESCRIPTION
As suggested in the screen comps in https://github.com/rubymonsters/fiftypercent/issues/36, I’ve made some changes to the look of the landing page:
- A new colour for the header (taken from the speakerinnen website);
- New colours for the donut charts;
- Colours for the links in the event title that fit the teal palette;
- a percentage sign in the donut chart to make the meaning of the numbers more explicit (with help from @jancborchardt and his amazing internet-search skills 😁)

<img width="1323" alt="Screenshot 2019-09-04 at 16 58 36" src="https://user-images.githubusercontent.com/3143348/64266687-4dfaa900-cf35-11e9-94fa-0a00f46c464b.png">
